### PR TITLE
feat: show missing token screen on startup if needed

### DIFF
--- a/src/main/java/me/doinkythederp/lanextender/LANExtenderMod.java
+++ b/src/main/java/me/doinkythederp/lanextender/LANExtenderMod.java
@@ -32,11 +32,11 @@ public class LANExtenderMod implements ModInitializer {
 
     public static final Text checkboxMessage = Text.translatable("lanServer.publish");
     public static Optional<CheckboxWidget> publishCheckbox = Optional.empty();
-
+    public static MinecraftClient client = MinecraftClient.getInstance();
     public static boolean ngrokInstalled = false;
+
     private static Path ngrokPath;
     private static Path configPath;
-
     private static Optional<NgrokClient> ngrokClient = Optional.empty();
     private static Optional<Integer> ngrokPort = Optional.empty();
     private static Optional<String> ngrokToken = Optional.empty();
@@ -49,6 +49,8 @@ public class LANExtenderMod implements ModInitializer {
 
         ngrokPath = FabricLoader.getInstance().getGameDir().resolve("lan_extender").resolve("ngrok");
         configPath = FabricLoader.getInstance().getConfigDir().resolve("LANExtenderAuthToken.txt");
+
+        ngrokToken = loadToken();
 
         if (ngrokPath.toFile().exists()) {
             ngrokInstalled = true;
@@ -116,7 +118,6 @@ public class LANExtenderMod implements ModInitializer {
             return;
         }
 
-        ngrokToken = loadToken();
         if (!ngrokToken.isPresent()) {
             LOGGER.warn("No ngrok token found, publishing LAN servers is not available.");
             return;
@@ -141,7 +142,7 @@ public class LANExtenderMod implements ModInitializer {
         if (ngrokPort.isPresent()) {
             int port = ngrokPort.get();
             ngrokPort = Optional.empty();
-            ChatHud chatHud = MinecraftClient.getInstance().inGameHud.getChatHud();
+            ChatHud chatHud = client.inGameHud.getChatHud();
             try {
                 Tunnel tunnel = publishPort(port);
                 chatHud.addMessage(

--- a/src/main/java/me/doinkythederp/lanextender/MissingTokenWarningScreen.java
+++ b/src/main/java/me/doinkythederp/lanextender/MissingTokenWarningScreen.java
@@ -1,0 +1,53 @@
+package me.doinkythederp.lanextender;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.WarningScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Util;
+
+public class MissingTokenWarningScreen extends WarningScreen {
+    private static boolean warningHasBeenShown = false;
+
+    public static boolean shouldSkipWarningCheck() {
+        return warningHasBeenShown /* || options.skipMissingTokenWarning */;
+    }
+
+    private static final Text HEADER = Text.translatable("warning.lan_extender.missing_authtoken.header")
+            .formatted(Formatting.BOLD);
+    private static final Text MESSAGE = Text.translatable("warning.lan_extender.missing_authtoken.message");
+    private static final Text CHECK_MESSAGE = Text.translatable("warning.lan_extender.missing_authtoken.check");
+    private static final Text SETUP_GUIDE = Text.translatable("warning.lan_extender.missing_authtoken.setup_guide");
+    private static final Text NARRATED_TEXT = HEADER.copy().append("\n").append(MESSAGE);
+    private final Screen parent;
+
+    private static final ContactInformation contactInfo = FabricLoader.getInstance()
+            .getModContainer("lan_extender").get()
+            .getMetadata().getContact();
+
+    public MissingTokenWarningScreen(Screen parent) {
+        super(HEADER, MESSAGE, CHECK_MESSAGE, NARRATED_TEXT);
+        this.parent = parent;
+    }
+
+    @Override
+    protected void initButtons(int yOffset) {
+        this.addDrawableChild(
+                new ButtonWidget(this.width / 2 - 155, 100 + yOffset, 150, 20, SETUP_GUIDE, buttonWidget -> {
+                    Util.getOperatingSystem().open(contactInfo.get("sources").get() + "#setup");
+                }));
+        this.addDrawableChild(new ButtonWidget(this.width / 2 - 155 + 160, 100 + yOffset, 150, 20, ScreenTexts.PROCEED,
+                buttonWidget -> {
+                    if (this.checkbox.isChecked()) {
+                        // this.client.options.skipMultiplayerWarning = true;
+                        // this.client.options.write();
+                    }
+                    warningHasBeenShown = true;
+                    this.client.setScreen(this.parent);
+                }));
+    }
+}

--- a/src/main/java/me/doinkythederp/lanextender/MissingTokenWarningScreen.java
+++ b/src/main/java/me/doinkythederp/lanextender/MissingTokenWarningScreen.java
@@ -1,5 +1,6 @@
 package me.doinkythederp.lanextender;
 
+import me.doinkythederp.lanextender.config.LANExtenderConfig;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.minecraft.client.gui.screen.Screen;
@@ -14,7 +15,8 @@ public class MissingTokenWarningScreen extends WarningScreen {
     private static boolean warningHasBeenShown = false;
 
     public static boolean shouldSkipWarningCheck() {
-        return warningHasBeenShown /* || options.skipMissingTokenWarning */;
+        var config = LANExtenderConfig.getInstance();
+        return warningHasBeenShown || config.hideAuthTokenMissingWarning;
     }
 
     private static final Text HEADER = Text.translatable("warning.lan_extender.missing_authtoken.header")
@@ -43,8 +45,9 @@ public class MissingTokenWarningScreen extends WarningScreen {
         this.addDrawableChild(new ButtonWidget(this.width / 2 - 155 + 160, 100 + yOffset, 150, 20, ScreenTexts.PROCEED,
                 buttonWidget -> {
                     if (this.checkbox.isChecked()) {
-                        // this.client.options.skipMultiplayerWarning = true;
-                        // this.client.options.write();
+                        var config = LANExtenderConfig.getInstance();
+                        config.hideAuthTokenMissingWarning = true;
+                        LANExtenderConfig.saveConfig();
                     }
                     warningHasBeenShown = true;
                     this.client.setScreen(this.parent);

--- a/src/main/java/me/doinkythederp/lanextender/mixin/TitleScreenMixin.java
+++ b/src/main/java/me/doinkythederp/lanextender/mixin/TitleScreenMixin.java
@@ -1,0 +1,25 @@
+package me.doinkythederp.lanextender.mixin;
+
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import me.doinkythederp.lanextender.LANExtenderMod;
+import me.doinkythederp.lanextender.MissingTokenWarningScreen;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import net.minecraft.client.gui.screen.TitleScreen;
+
+@Mixin(TitleScreen.class)
+public class TitleScreenMixin {
+    @Inject(at = @At("TAIL"), method = "init()V")
+    private void showSetupScreenIfAuthtokenMissing(CallbackInfo info) {
+        if (MissingTokenWarningScreen.shouldSkipWarningCheck()) {
+            return;
+        }
+
+        if (LANExtenderMod.getNgrokToken().orElse("").isEmpty()) {
+            LANExtenderMod.client.setScreen(new MissingTokenWarningScreen((TitleScreen) (Object) this));
+        }
+    }
+}

--- a/src/main/resources/assets/lan_extender/lang/en_us.json
+++ b/src/main/resources/assets/lan_extender/lang/en_us.json
@@ -3,5 +3,9 @@
     "title.lan_extender.config": "LAN Extender Options",
     "option.lan_extender.auth_token": "Ngrok Authtoken",
     "tooltip.lan_extender.auth_token": "Get this from \"Your Authtoken\" at www.ngrok.com",
-    "error.lan_extender.failed_to_publish": "Failed to publish LAN server. Is your ngrok authtoken valid?"
+    "error.lan_extender.failed_to_publish": "Failed to publish LAN server. Is your ngrok authtoken valid?",
+    "warning.lan_extender.missing_authtoken.header": "LAN Extender has not been set up",
+    "warning.lan_extender.missing_authtoken.message": "You will not be able to share your LAN worlds to the Internet until you connect LAN Extender to your Ngrok account. To read the setup guide, click Learn More.",
+    "warning.lan_extender.missing_authtoken.check": "Do not show this screen again",
+    "warning.lan_extender.missing_authtoken.setup_guide": "Learn More…"
 }

--- a/src/main/resources/lan_extender.mixins.json
+++ b/src/main/resources/lan_extender.mixins.json
@@ -8,7 +8,8 @@
         "OpenToLANScreenMixin",
         "ScreenAccessor",
         "IntegratedServerMixin",
-        "MinecraftClientMixin"
+        "MinecraftClientMixin",
+        "TitleScreenMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
**What changes does this PR make and why should it be merged:**
This PR adds a warning screen when the game starts if LAN Extender has not been configured. The screen will be have to ability to be dismissed permanently with a checkbox, similarly to the multiplayer warning screen. However, this will require a rework of the config system. Closes #4.

- Code changes have been tested in-game
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
