### PR TITLE
refactor: rework ngrok logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please note that the authtoken pictured in this guide will not work if you try t
 
 ## Usage
 
-Once you're in the world you want others to be able to join, click Open to LAN in the game menu and click the checkbox to allow people connected to a different router to join.
+Once you're in the world you want others to be able to join, click Open to LAN in the game menu and click the checkbox to allow people connected to a different router to join. **If the checkbox is missing, you need to follow the setup guide.**
 
 ![Click the checkbox](assets/open_to_lan.png)
 ![View the address in chat](assets/opened_to_lan.png)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please note that the authtoken pictured in this guide will not work if you try t
 
 ## Usage
 
-Once you're in the world you want others to be able to join, click Open to LAN in the game menu and click the checkbox to allow people connected to a different router to join. **If the checkbox is missing, you need to follow the setup guide.**
+Once you're in the world you want others to be able to join, click Open to LAN in the game menu and click the checkbox to allow people connected to a different router to join. **If the checkbox is missing, you need to follow the setup guide above.**
 
 ![Click the checkbox](assets/open_to_lan.png)
 ![View the address in chat](assets/opened_to_lan.png)

--- a/src/main/java/me/doinkythederp/lanextender/LANExtenderMod.java
+++ b/src/main/java/me/doinkythederp/lanextender/LANExtenderMod.java
@@ -1,25 +1,14 @@
 package me.doinkythederp.lanextender;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.widget.CheckboxWidget;
 import net.minecraft.text.Text;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.github.alexdlaird.ngrok.NgrokClient;
-import com.github.alexdlaird.ngrok.conf.JavaNgrokConfig;
-import com.github.alexdlaird.ngrok.installer.NgrokInstaller;
-import com.github.alexdlaird.ngrok.protocol.CreateTunnel;
-import com.github.alexdlaird.ngrok.protocol.Proto;
-import com.github.alexdlaird.ngrok.protocol.Tunnel;
 
 import me.doinkythederp.lanextender.config.LANExtenderConfig;
 
@@ -31,11 +20,7 @@ public class LANExtenderMod implements ModInitializer {
     public static final Text checkboxMessage = Text.translatable("lanServer.publish");
     public static Optional<CheckboxWidget> publishCheckbox = Optional.empty();
     public static MinecraftClient client = MinecraftClient.getInstance();
-    public static boolean ngrokInstalled = false;
-
-    private static Path ngrokPath;
-    private static Optional<NgrokClient> ngrokClient = Optional.empty();
-    private static Optional<Integer> ngrokPort = Optional.empty();
+    public static WorldPublisher publisher = new WorldPublisher();
 
     @Override
     public void onInitialize() {
@@ -43,109 +28,17 @@ public class LANExtenderMod implements ModInitializer {
         // However, some things (like resources) may still be uninitialized.
         // Proceed with mild caution.
 
-        ngrokPath = FabricLoader.getInstance().getGameDir().resolve("lan_extender").resolve("ngrok");
-
         LANExtenderConfig.loadConfig();
 
-        if (ngrokPath.toFile().exists()) {
-            ngrokInstalled = true;
-            LOGGER.info("Ngrok is already installed.", ngrokPath);
-            startNgrokClient();
-        } else {
-            LOGGER.info("Installing ngrok to `{}`…", ngrokPath);
-            new Thread(() -> {
-                var ngrokInstaller = new NgrokInstaller();
-                try {
-                    ngrokInstaller.installNgrok(ngrokPath);
-                    ngrokInstalled = true;
-                    LOGGER.info("Finished installing ngrok.");
-                    startNgrokClient();
-                } catch (Exception e) {
-                    LOGGER.error("Failed to install ngrok: {}", e.getMessage());
-                }
-            }).start();
-        }
-    }
-
-    private static void startNgrokClient() {
-        if (!ngrokInstalled) {
-            LOGGER.warn("Ngrok is not installed, publishing LAN servers is not available.");
-            return;
-        }
-
-        final String ngrokToken = LANExtenderConfig.getInstance().authToken;
-        if (ngrokToken.isEmpty()) {
-            LOGGER.warn("No ngrok token found, publishing LAN servers is not available.");
-            return;
-        }
-        if (ngrokClient.isPresent()) {
-            LOGGER.debug("Stopping ngrok client!");
-            disconnectTunnel();
-            ngrokClient.get().kill();
-        }
-
-        Path ngrokBinaryPath = isWindows() ? ngrokPath.resolveSibling("ngrok.exe") : ngrokPath;
-
-        var config = new JavaNgrokConfig.Builder()
-                .withAuthToken(ngrokToken)
-                .withNgrokPath(
-                        ngrokBinaryPath)
-                .build();
-        ngrokClient = Optional.of(new NgrokClient.Builder()
-                .withJavaNgrokConfig(config)
-                .build());
-
-        if (ngrokPort.isPresent()) {
-            int port = ngrokPort.get();
-            ngrokPort = Optional.empty();
-            ChatHud chatHud = client.inGameHud.getChatHud();
+        var config = LANExtenderConfig.getInstance();
+        new Thread(() -> {
             try {
-                Tunnel tunnel = publishPort(port);
-                chatHud.addMessage(
-                        Text.literal("Your server is now available @ " + tunnel.getPublicUrl().replace("tcp://", "")));
+                publisher.restartClient(config.authToken);
+                LOGGER.info("LAN Extender is initialized. Have fun sharing your worlds!");
             } catch (Exception e) {
-                chatHud.addMessage(Text.translatable("error.lan_extender.failed_to_publish"));
+                LOGGER.error("Failed to start ngrok client: {}", e);
             }
-
-        }
-    }
-
-    public static boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase().contains("win");
-    }
-
-    public static Tunnel publishPort(int port) throws IllegalStateException {
-        if (ngrokPort.isPresent()) {
-            throw new IllegalStateException("Already publishing to port " + ngrokPort.get());
-        }
-        if (!ngrokClient.isPresent()) {
-            throw new IllegalStateException("Ngrok client not ready");
-        }
-        ngrokPort = Optional.of(port);
-        var tunnel = new CreateTunnel.Builder()
-                .withProto(Proto.TCP)
-                .withAddr(port)
-                .build();
-        return ngrokClient.get().connect(tunnel);
-    }
-
-    public static void disconnectTunnel() {
-        if (!ngrokClient.isPresent()) {
-            return;
-        }
-
-        List<Tunnel> tunnels;
-        try {
-            tunnels = ngrokClient.get().getTunnels();
-        } catch (Exception e) {
-            tunnels = new ArrayList<>();
-        }
-
-        tunnels.forEach(tunnel -> {
-            LOGGER.debug("Disconnecting tunnel {}", tunnel.getName());
-            ngrokClient.get().disconnect(tunnel.getPublicUrl());
-        });
-        ngrokPort = Optional.empty();
+        }, "LAN-Extender-Initializer").start();
     }
 
     /**

--- a/src/main/java/me/doinkythederp/lanextender/OperatingSystemDetector.java
+++ b/src/main/java/me/doinkythederp/lanextender/OperatingSystemDetector.java
@@ -1,0 +1,7 @@
+package me.doinkythederp.lanextender;
+
+public class OperatingSystemDetector {
+    public static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+}

--- a/src/main/java/me/doinkythederp/lanextender/WorldPublisher.java
+++ b/src/main/java/me/doinkythederp/lanextender/WorldPublisher.java
@@ -29,6 +29,7 @@ public class WorldPublisher {
     private Optional<Integer> publishedPort = Optional.empty();
 
     public void restartClient(String authToken) {
+        LOGGER.info("Starting ngrok client");
         this.installNgrokIfNeeded();
 
         if (ngrokClient.isPresent()) {

--- a/src/main/java/me/doinkythederp/lanextender/WorldPublisher.java
+++ b/src/main/java/me/doinkythederp/lanextender/WorldPublisher.java
@@ -1,0 +1,113 @@
+package me.doinkythederp.lanextender;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.github.alexdlaird.ngrok.NgrokClient;
+import com.github.alexdlaird.ngrok.conf.JavaNgrokConfig;
+import com.github.alexdlaird.ngrok.installer.NgrokInstaller;
+import com.github.alexdlaird.ngrok.protocol.CreateTunnel;
+import com.github.alexdlaird.ngrok.protocol.Proto;
+import com.github.alexdlaird.ngrok.protocol.Tunnel;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.text.Text;
+
+import static me.doinkythederp.lanextender.LANExtenderMod.LOGGER;
+
+public class WorldPublisher {
+    private static final Path NGROK_INSTALL_PATH = FabricLoader.getInstance()
+            .getGameDir()
+            .resolve("lan_extender")
+            .resolve("ngrok");
+    private static final Path NGROK_PATH = OperatingSystemDetector.isWindows()
+            ? NGROK_INSTALL_PATH.resolveSibling("ngrok.exe")
+            : NGROK_INSTALL_PATH;
+
+    private Optional<NgrokClient> ngrokClient = Optional.empty();
+    private boolean ngrokInstalled = NGROK_PATH.toFile().exists();
+    private Optional<Integer> publishedPort = Optional.empty();
+
+    public void restartClient(String authToken) {
+        this.installNgrokIfNeeded();
+
+        if (ngrokClient.isPresent()) {
+            ngrokClient.get().kill();
+        }
+
+        var ngrokConfig = new JavaNgrokConfig.Builder()
+                .withAuthToken(authToken)
+                .withNgrokPath(NGROK_PATH)
+                .build();
+        NgrokClient ngrokClient = new NgrokClient.Builder()
+                .withJavaNgrokConfig(ngrokConfig)
+                .build();
+
+        this.ngrokClient = Optional.of(ngrokClient);
+
+        if (publishedPort.isPresent()) {
+            int port = publishedPort.get();
+            publishedPort = Optional.empty();
+            try {
+                Tunnel tunnel = this.publishPort(port);
+                LANExtenderMod.client.inGameHud.getChatHud().addMessage(
+                        Text.translatable("message.lan_extender.address_changed", getTunnelAddress(tunnel)));
+            } catch (Exception e) {
+                LOGGER.error("Failed to re-publish port {}: {}", port, e);
+            }
+        }
+    }
+
+    private void installNgrokIfNeeded() {
+        if (this.ngrokInstalled) {
+            return;
+        }
+
+        LOGGER.info("Installing ngrok client");
+        var ngrokInstaller = new NgrokInstaller();
+        try {
+            ngrokInstaller.installNgrok(NGROK_INSTALL_PATH);
+            this.ngrokInstalled = true;
+        } catch (Exception e) {
+            LOGGER.error("Failed to install ngrok client");
+            throw e;
+        }
+        LOGGER.info("Finished installing ngrok.");
+    }
+
+    public boolean isReadyToPublish() {
+        return this.ngrokClient.isPresent() && this.publishedPort.isEmpty()
+                && !this.ngrokClient.get().getJavaNgrokConfig().getAuthToken().isEmpty();
+    }
+
+    public Tunnel publishPort(int port) {
+        if (publishedPort.isPresent()) {
+            throw new IllegalStateException("Cannot publish port, already publishing another port");
+        }
+        if (!this.isReadyToPublish()) {
+            throw new IllegalStateException("Not ready to publish port");
+        }
+
+        LOGGER.info("Publishing port {} to ngrok", port);
+
+        this.publishedPort = Optional.of(port);
+        var createTunnel = new CreateTunnel.Builder()
+                .withProto(Proto.TCP)
+                .withAddr(port)
+                .build();
+        Tunnel tunnel = this.ngrokClient.get().connect(createTunnel);
+        LOGGER.info("Public URL is {}", tunnel.getPublicUrl());
+        return tunnel;
+    }
+
+    public void closePort() {
+        LOGGER.info("Unpublishing all ports");
+        var ngrok = this.ngrokClient.get();
+        ngrok.getTunnels().forEach(tunnel -> ngrok.disconnect(tunnel.getPublicUrl()));
+        publishedPort = Optional.empty();
+    }
+
+    public static String getTunnelAddress(Tunnel tunnel) {
+        return tunnel.getPublicUrl().replace("tcp://", "");
+    }
+}

--- a/src/main/java/me/doinkythederp/lanextender/config/LANExtenderConfig.java
+++ b/src/main/java/me/doinkythederp/lanextender/config/LANExtenderConfig.java
@@ -34,7 +34,6 @@ public class LANExtenderConfig {
         LOGGER.info("Loading configuration file");
 
         try {
-            // TODO: fall back to LANExtenderAuthToken.txt
             Optional<LANExtenderConfig> config = readConfig();
             if (config.isPresent()) {
                 CONFIG_INSTANCE = config;

--- a/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
+++ b/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
@@ -1,38 +1,33 @@
 package me.doinkythederp.lanextender.config;
 
-import java.util.Optional;
-
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 
+import me.doinkythederp.lanextender.LANExtenderMod;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;
 import net.minecraft.text.Text;
 
 public class LANExtenderModMenuIntegration implements ModMenuApi {
-    private static Optional<String> unsavedAuthToken = Optional.empty();
-
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> {
             final var config = LANExtenderConfig.getInstance();
-            unsavedAuthToken = Optional.of(config.authToken);
             ConfigBuilder builder = ConfigBuilder.create()
                     .setParentScreen(parent)
                     .setTitle(Text.translatable("title.lan_extender.config"))
                     .setSavingRunnable(() -> {
-                        config.authToken = unsavedAuthToken.get();
                         LANExtenderConfig.saveConfig();
-                        unsavedAuthToken = Optional.empty();
+                        LANExtenderMod.publisher.restartClient(config.authToken);
                     });
             ConfigCategory general = builder.getOrCreateCategory(Text.translatable("category.lan_extender.general"));
             general.addEntry(builder.entryBuilder()
                     .startStrField(Text.translatable("option.lan_extender.auth_token"),
-                            unsavedAuthToken.get())
+                            config.authToken)
                     .setDefaultValue("")
                     .setTooltip(Text.translatable("tooltip.lan_extender.auth_token"))
                     .setSaveConsumer(value -> {
-                        unsavedAuthToken = Optional.of(value);
+                        config.authToken = value;
                     }).build());
             return builder.build();
 

--- a/src/main/java/me/doinkythederp/lanextender/mixin/IntegratedServerMixin.java
+++ b/src/main/java/me/doinkythederp/lanextender/mixin/IntegratedServerMixin.java
@@ -7,8 +7,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.github.alexdlaird.ngrok.protocol.Tunnel;
-
 import me.doinkythederp.lanextender.LANExtenderMod;
 import me.doinkythederp.lanextender.config.LANExtenderConfig;
 
@@ -43,23 +41,26 @@ public class IntegratedServerMixin {
                                 "LAN Extender requires an ngrok authtoken to publish servers. Read the mod's guide for more information."));
                 return;
             }
-
-            try {
-                Tunnel tunnel = LANExtenderMod.publishPort(port);
-                chat.addMessage(Text
-                        .literal("Your server is joinable @ "
-                                + tunnel.getPublicUrl().replace("tcp://", "")));
-            } catch (Exception e) {
-                LANExtenderMod.LOGGER.error(e.getClass().getSimpleName() + ": "
-                        + e.getMessage());
-                chat.addMessage(
-                        Text.translatable("error.lan_extender.failed_to_publish"));
-            }
+            // TODO
+            /*
+             * try {
+             * Tunnel tunnel = LANExtenderMod.publishPort(port);
+             * chat.addMessage(Text
+             * .literal("Your server is joinable @ "
+             * + tunnel.getPublicUrl().replace("tcp://", "")));
+             * } catch (Exception e) {
+             * LANExtenderMod.LOGGER.error(e.getClass().getSimpleName() + ": "
+             * + e.getMessage());
+             * chat.addMessage(
+             * Text.translatable("error.lan_extender.failed_to_publish"));
+             * }
+             */
         }
     }
 
     @Inject(at = @At("RETURN"), method = "stop")
     private void afterStop(boolean joinServerThread, CallbackInfo info) {
-        LANExtenderMod.disconnectTunnel();
+        // TODO
+        /* LANExtenderMod.disconnectTunnel(); */
     }
 }

--- a/src/main/java/me/doinkythederp/lanextender/mixin/IntegratedServerMixin.java
+++ b/src/main/java/me/doinkythederp/lanextender/mixin/IntegratedServerMixin.java
@@ -42,7 +42,7 @@ public class IntegratedServerMixin {
                             Text.translatable("message.lan_extender.world_published",
                                     WorldPublisher.getTunnelAddress(tunnel)));
                 } catch (Exception e) {
-                    LANExtenderMod.LOGGER.error("Failed to publish port: {}", e);
+                    LANExtenderMod.LOGGER.error("Failed to publish port:", e);
                     chat.addMessage(
                             Text.translatable("error.lan_extender.failed_to_publish"));
                 }

--- a/src/main/java/me/doinkythederp/lanextender/mixin/OpenToLANScreenMixin.java
+++ b/src/main/java/me/doinkythederp/lanextender/mixin/OpenToLANScreenMixin.java
@@ -17,6 +17,10 @@ import net.minecraft.client.gui.widget.CheckboxWidget;
 public abstract class OpenToLANScreenMixin {
     @Inject(at = @At("TAIL"), method = "init()V")
     private void init(CallbackInfo info) {
+        if (!LANExtenderMod.publisher.isReadyToPublish()) {
+            return;
+        }
+
         var lanScreen = (ScreenAccessor) (Object) this;
         int messageWidth = lanScreen.getTextRenderer().getWidth(LANExtenderMod.checkboxMessage);
         LANExtenderMod.publishCheckbox = Optional.of(

--- a/src/main/resources/assets/lan_extender/lang/en_us.json
+++ b/src/main/resources/assets/lan_extender/lang/en_us.json
@@ -3,10 +3,11 @@
     "title.lan_extender.config": "LAN Extender Options",
     "option.lan_extender.auth_token": "Ngrok Authtoken",
     "tooltip.lan_extender.auth_token": "Get this from \"Your Authtoken\" at www.ngrok.com",
-    "error.lan_extender.failed_to_publish": "Failed to publish LAN server. Is your ngrok authtoken valid?",
+    "error.lan_extender.failed_to_publish": "Failed to publish your world. Please verify that your ngrok authtoken is correct.",
     "warning.lan_extender.missing_authtoken.header": "LAN Extender has not been set up",
     "warning.lan_extender.missing_authtoken.message": "You will not be able to share your LAN worlds to the Internet until you connect LAN Extender to your Ngrok account. To read the setup guide, click Learn More.",
     "warning.lan_extender.missing_authtoken.check": "Do not show this screen again",
     "warning.lan_extender.missing_authtoken.setup_guide": "Learn More…",
-    "message.lan_extender.address_changed": "Your world's address has been changed to {}"
+    "message.lan_extender.address_changed": "Your world's address has been changed to %s",
+    "message.lan_extender.world_published": "Your world has been published! Join it @ %s"
 }

--- a/src/main/resources/assets/lan_extender/lang/en_us.json
+++ b/src/main/resources/assets/lan_extender/lang/en_us.json
@@ -7,5 +7,6 @@
     "warning.lan_extender.missing_authtoken.header": "LAN Extender has not been set up",
     "warning.lan_extender.missing_authtoken.message": "You will not be able to share your LAN worlds to the Internet until you connect LAN Extender to your Ngrok account. To read the setup guide, click Learn More.",
     "warning.lan_extender.missing_authtoken.check": "Do not show this screen again",
-    "warning.lan_extender.missing_authtoken.setup_guide": "Learn More…"
+    "warning.lan_extender.missing_authtoken.setup_guide": "Learn More…",
+    "message.lan_extender.address_changed": "Your world's address has been changed to {}"
 }


### PR DESCRIPTION
**What changes does this PR make and why should it be merged:**
This PR moves more logic out of `LANExtenderMod` to make the mod more stable and also hides the checkbox for publishing worlds when the authtoken is missing or ngrok failed to install. Closes #8.

- Code changes have been tested in-game
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
