### PR TITLE
Add config back since Cloth doesn't support 1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 	// for more information about repositories.
     maven { url "https://maven.terraformersmc.com/" }
     maven { url "https://maven.shedaniel.me/" }
+    maven { url = "https://maven.isxander.dev/releases" }
 }
 
 dependencies {
@@ -27,7 +28,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-    modImplementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
+    modImplementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
 
 	// Uncomment the following line to enable the deprecated Fabric API modules.
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name = lan-extender-fabric-mc1.19
 # Mod Dependencies
 fabric_version=0.68.1+1.19.3
 modmenu_version=5.0.0
-yacl_version=2.0.0
+yacl_version=2.1.0
 
 # Dependencies
 ngrok_version=1.5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name = lan-extender-fabric-mc1.19
 # Mod Dependencies
 fabric_version=0.68.1+1.19.3
 modmenu_version=5.0.0
-cloth_config_version=7.0.65
+yacl_version=2.0.0
 
 # Dependencies
 ngrok_version=1.5.6

--- a/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
+++ b/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
@@ -7,6 +7,7 @@ import com.terraformersmc.modmenu.api.ModMenuApi;
 import dev.isxander.yacl.api.ConfigCategory;
 import dev.isxander.yacl.api.Option;
 import dev.isxander.yacl.api.YetAnotherConfigLib;
+import dev.isxander.yacl.gui.controllers.string.StringController;
 import me.doinkythederp.lanextender.LANExtenderMod;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
@@ -31,7 +32,18 @@ public class LANExtenderModMenuIntegration implements ModMenuApi {
                     })
                     .category(ConfigCategory.createBuilder()
                             .name(Text.translatable(
-                                    "category.lan_extender.general"))
+                                    "title.lan_extender.config"))
+                            .option(Option.createBuilder(String.class)
+                                    .name(Text.translatable(
+                                            "option.lan_extender.auth_token"))
+                                    .tooltip(Text.translatable(
+                                            "tooltip.lan_extender.auth_token"))
+                                    .binding(
+                                            config.authToken,
+                                            () -> config.authToken,
+                                            newValue -> config.authToken = newValue)
+                                    .controller(StringController::new)
+                                    .build())
                             .build())
                     .build()
                     .generateScreen(parent);

--- a/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
+++ b/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
@@ -4,9 +4,11 @@ import com.github.alexdlaird.ngrok.protocol.Region;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 
+import dev.isxander.yacl.api.ConfigCategory;
+import dev.isxander.yacl.api.Option;
+import dev.isxander.yacl.api.YetAnotherConfigLib;
 import me.doinkythederp.lanextender.LANExtenderMod;
-import me.shedaniel.clothconfig2.api.ConfigBuilder;
-import me.shedaniel.clothconfig2.api.ConfigCategory;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
 
 public class LANExtenderModMenuIntegration implements ModMenuApi {
@@ -22,49 +24,61 @@ public class LANExtenderModMenuIntegration implements ModMenuApi {
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> {
             final var config = LANExtenderConfig.getInstance();
-            ConfigBuilder builder = ConfigBuilder.create()
-                    .setParentScreen(parent)
-                    .setTitle(Text.translatable("title.lan_extender.config"))
-                    .setSavingRunnable(() -> {
+            return YetAnotherConfigLib.createBuilder()
+                    .title(Text.translatable("title.lan_extender.config"))
+                    .save(() -> {
                         LANExtenderConfig.saveConfig();
-                        LANExtenderMod.publisher.restartClient(config.authToken, config.region);
-                    });
+                    })
+                    .category(ConfigCategory.createBuilder()
+                            .name(Text.translatable(
+                                    "category.lan_extender.general"))
+                            .build())
+                    .build()
+                    .generateScreen(parent);
+            // ConfigBuilder builder = ConfigBuilder.create()
+            // .setParentScreen(parent)
+            // .setTitle(Text.translatable("title.lan_extender.config"))
+            // .setSavingRunnable(() -> {
+            // LANExtenderConfig.saveConfig();
+            // LANExtenderMod.publisher.restartClient(config.authToken, config.region);
+            // });
 
-            // #region General
-            ConfigCategory general = builder.getOrCreateCategory(Text.translatable("category.lan_extender.general"));
+            // // #region General
+            // ConfigCategory general =
+            // builder.getOrCreateCategory(Text.translatable("category.lan_extender.general"));
 
-            general.addEntry(builder.entryBuilder()
-                    .startStrField(Text.translatable("option.lan_extender.auth_token"),
-                            config.authToken)
-                    .setDefaultValue("")
-                    .setTooltip(Text.translatable("tooltip.lan_extender.auth_token"))
-                    .setSaveConsumer(value -> {
-                        config.authToken = value;
-                    }).build());
+            // general.addEntry(builder.entryBuilder()
+            // .startStrField(Text.translatable("option.lan_extender.auth_token"),
+            // config.authToken)
+            // .setDefaultValue("")
+            // .setTooltip(Text.translatable("tooltip.lan_extender.auth_token"))
+            // .setSaveConsumer(value -> {
+            // config.authToken = value;
+            // }).build());
 
-            general.addEntry(builder.entryBuilder()
-                    .startEnumSelector(Text.translatable("option.lan_extender.region"),
-                            Region.class, config.region)
-                    .setDefaultValue(Region.US)
-                    .setEnumNameProvider(
-                            LANExtenderModMenuIntegration::regionToText)
-                    .setTooltip(Text.translatable("tooltip.lan_extender.region"))
-                    .setSaveConsumer(value -> {
-                        config.region = value;
-                    }).build());
+            // general.addEntry(builder.entryBuilder()
+            // .startEnumSelector(Text.translatable("option.lan_extender.region"),
+            // Region.class, config.region)
+            // .setDefaultValue(Region.US)
+            // .setEnumNameProvider(
+            // LANExtenderModMenuIntegration::regionToText)
+            // .setTooltip(Text.translatable("tooltip.lan_extender.region"))
+            // .setSaveConsumer(value -> {
+            // config.region = value;
+            // }).build());
 
-            general.addEntry(builder.entryBuilder()
-                    .startBooleanToggle(Text.translatable("option.lan_extender.copy_on_publish"),
-                            config.copyAddressOnPublish)
-                    .setDefaultValue(true)
-                    .setTooltip(Text.translatable("tooltip.lan_extender.copy_on_publish"))
-                    .setSaveConsumer(value -> {
-                        config.copyAddressOnPublish = value;
-                    }).build());
+            // general.addEntry(builder.entryBuilder()
+            // .startBooleanToggle(Text.translatable("option.lan_extender.copy_on_publish"),
+            // config.copyAddressOnPublish)
+            // .setDefaultValue(true)
+            // .setTooltip(Text.translatable("tooltip.lan_extender.copy_on_publish"))
+            // .setSaveConsumer(value -> {
+            // config.copyAddressOnPublish = value;
+            // }).build());
 
-            // #endregion
+            // // #endregion
 
-            return builder.build();
+            // return builder.build();
 
         };
     }

--- a/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
+++ b/src/main/java/me/doinkythederp/lanextender/config/LANExtenderModMenuIntegration.java
@@ -7,6 +7,8 @@ import com.terraformersmc.modmenu.api.ModMenuApi;
 import dev.isxander.yacl.api.ConfigCategory;
 import dev.isxander.yacl.api.Option;
 import dev.isxander.yacl.api.YetAnotherConfigLib;
+import dev.isxander.yacl.gui.controllers.BooleanController;
+import dev.isxander.yacl.gui.controllers.cycling.EnumController;
 import dev.isxander.yacl.gui.controllers.string.StringController;
 import me.doinkythederp.lanextender.LANExtenderMod;
 import net.minecraft.client.gui.screen.Screen;
@@ -39,59 +41,31 @@ public class LANExtenderModMenuIntegration implements ModMenuApi {
                                     .tooltip(Text.translatable(
                                             "tooltip.lan_extender.auth_token"))
                                     .binding(
-                                            config.authToken,
+                                            "",
                                             () -> config.authToken,
                                             newValue -> config.authToken = newValue)
                                     .controller(StringController::new)
                                     .build())
+                            .option(Option.createBuilder(Region.class)
+                                    .name(Text.translatable("option.lan_extender.region"))
+                                    .tooltip(Text.translatable("tooltip.lan_extender.region"))
+                                    .binding(Region.US, () -> config.region, region -> config.region = region)
+                                    .controller(option -> new EnumController<Region>(
+                                            option, region -> LANExtenderModMenuIntegration.regionToText(region)))
+                                    .build())
+                            .option(Option.createBuilder(Boolean.class)
+                                    .name(Text.translatable(
+                                            "option.lan_extender.copy_on_publish"))
+                                    .tooltip(Text.translatable(
+                                            "tooltip.lan_extender.copy_on_publish"))
+                                    .binding(true, () -> config.copyAddressOnPublish,
+                                            value -> config.copyAddressOnPublish = value)
+                                    .controller(
+                                            BooleanController::new)
+                                    .build())
                             .build())
                     .build()
                     .generateScreen(parent);
-            // ConfigBuilder builder = ConfigBuilder.create()
-            // .setParentScreen(parent)
-            // .setTitle(Text.translatable("title.lan_extender.config"))
-            // .setSavingRunnable(() -> {
-            // LANExtenderConfig.saveConfig();
-            // LANExtenderMod.publisher.restartClient(config.authToken, config.region);
-            // });
-
-            // // #region General
-            // ConfigCategory general =
-            // builder.getOrCreateCategory(Text.translatable("category.lan_extender.general"));
-
-            // general.addEntry(builder.entryBuilder()
-            // .startStrField(Text.translatable("option.lan_extender.auth_token"),
-            // config.authToken)
-            // .setDefaultValue("")
-            // .setTooltip(Text.translatable("tooltip.lan_extender.auth_token"))
-            // .setSaveConsumer(value -> {
-            // config.authToken = value;
-            // }).build());
-
-            // general.addEntry(builder.entryBuilder()
-            // .startEnumSelector(Text.translatable("option.lan_extender.region"),
-            // Region.class, config.region)
-            // .setDefaultValue(Region.US)
-            // .setEnumNameProvider(
-            // LANExtenderModMenuIntegration::regionToText)
-            // .setTooltip(Text.translatable("tooltip.lan_extender.region"))
-            // .setSaveConsumer(value -> {
-            // config.region = value;
-            // }).build());
-
-            // general.addEntry(builder.entryBuilder()
-            // .startBooleanToggle(Text.translatable("option.lan_extender.copy_on_publish"),
-            // config.copyAddressOnPublish)
-            // .setDefaultValue(true)
-            // .setTooltip(Text.translatable("tooltip.lan_extender.copy_on_publish"))
-            // .setSaveConsumer(value -> {
-            // config.copyAddressOnPublish = value;
-            // }).build());
-
-            // // #endregion
-
-            // return builder.build();
-
         };
     }
 

--- a/src/main/resources/assets/lan_extender/lang/en_us.json
+++ b/src/main/resources/assets/lan_extender/lang/en_us.json
@@ -1,6 +1,6 @@
 {
     "lanServer.publish": "Publish to the internet",
-    "title.lan_extender.config": "LAN Extender Options",
+    "title.lan_extender.config": "LAN Extender",
     "option.lan_extender.auth_token": "Ngrok Authtoken",
     "tooltip.lan_extender.auth_token": "Get this from \"Your Authtoken\" at dashboard.ngrok.com",
     "option.lan_extender.region": "Region",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
         "fabric": "*",
         "minecraft": "^1.19.3",
         "java": ">=17",
-        "cloth-config": ["7.x", "8.x"]
+        "yet-another-config-lib": "2.x"
     },
     "suggests": {
         "modmenu": ">=5"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
         "fabric": "*",
         "minecraft": "^1.19.3",
         "java": ">=17",
-        "yet-another-config-lib": "2.x"
+        "yet-another-config-lib": "^2.1.0"
     },
     "suggests": {
         "modmenu": ">=5"


### PR DESCRIPTION
**What changes does this PR make and why should it be merged:**
This PR makes the config screen usable in 1.19.3 by using YACL instead because there is no Cloth Config version that supports that version.

- Code changes have been tested in-game